### PR TITLE
Increase unhealthy threshold

### DIFF
--- a/author.tf
+++ b/author.tf
@@ -6,7 +6,7 @@ resource "aws_alb_target_group" "author" {
 
   health_check = {
     healthy_threshold   = 2
-    unhealthy_threshold = 10
+    unhealthy_threshold = 20
     interval            = 10
     timeout             = 2
     path                = "/"


### PR DESCRIPTION
Unhealthy threshold increased to overcome failed deployment due to long build times on author.