### PR TITLE
Enable fullstory on amazon ecs.

### DIFF
--- a/task-definitions/author.json
+++ b/task-definitions/author.json
@@ -30,6 +30,10 @@
       {
         "name": "REACT_APP_GO_LAUNCH_A_SURVEY_URL",
         "value": "${SURVEY_LAUNCHER_URL}/quick-launch"
+      },
+      {
+        "name": "REACT_APP_USE_FULLSTORY",
+        "value": "true"
       }
     ],
     "logConfiguration": {


### PR DESCRIPTION
### Description
This PR sets an environment variable `REACT_APP_USE_FULLSTORY` to `true` so that the full story service is enabled when built for Amazon ECS.

### How to test
Should observe fullstory sessions when browsing staging environment.