### PR TITLE
Enable sentry logging for the front end in Amazon ECS.

### DIFF
--- a/task-definitions/author.json
+++ b/task-definitions/author.json
@@ -34,6 +34,10 @@
       {
         "name": "REACT_APP_USE_FULLSTORY",
         "value": "true"
+      },
+      {
+        "name": "REACT_APP_USE_SENTRY",
+        "value": "true"
       }
     ],
     "logConfiguration": {


### PR DESCRIPTION
### Description
This PR enables front end logging using Sentry.io for the author application running in Amazon's ECS.

### How to review.
The environment variable should be set to true.
Sentry.io should log errors and warnings in the staging environment.