### PR TITLE
Add env variable for schema validator URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,6 @@ module "author" {
   aws_alb_listener_arn    = "${module.eq-ecs.aws_alb_listener_arn}"
   application_cidrs       = "${var.application_cidrs}"
   survey_launcher_url     = "${module.survey-launcher-for-ecs.survey_runner_launcher_address}"
+  schema_validator_url    = "${module.schema-validator-for-ecs.schema_validator_address}"
 }
 ```

--- a/author.tf
+++ b/author.tf
@@ -54,7 +54,6 @@ data "template_file" "author" {
     FIREBASE_PROJECT_ID          = "${var.firebase_project_id}"
     FIREBASE_API_KEY             = "${var.firebase_api_key}"
     FIREBASE_MESSAGING_SENDER_ID = "${var.firebase_messaging_sender_id}"
-    SCHEMA_VALIDATOR_URL         = "${var.schema_validator_url}"
   }
 }
 

--- a/author.tf
+++ b/author.tf
@@ -54,6 +54,7 @@ data "template_file" "author" {
     FIREBASE_PROJECT_ID          = "${var.firebase_project_id}"
     FIREBASE_API_KEY             = "${var.firebase_api_key}"
     FIREBASE_MESSAGING_SENDER_ID = "${var.firebase_messaging_sender_id}"
+    SCHEMA_VALIDATOR_URL         = "${var.schema_validator_url}"
   }
 }
 

--- a/global_vars.tf
+++ b/global_vars.tf
@@ -78,3 +78,8 @@ variable "firebase_messaging_sender_id" {
   description = "The Firebase authentication sender id"
   default     = ""
 }
+
+variable "schema_validator_url" {
+  description = "The URL for the schema validator service"
+}
+

--- a/publisher.tf
+++ b/publisher.tf
@@ -44,10 +44,11 @@ data "template_file" "publisher" {
   template = "${file("${path.module}/task-definitions/publisher.json")}"
 
   vars {
-    LOG_GROUP          = "${aws_cloudwatch_log_group.publisher.name}"
-    CONTAINER_REGISTRY = "${var.docker_registry}"
-    CONTAINER_TAG      = "${var.publisher_tag}"
-    AUTHOR_API         = "https://${aws_route53_record.author-api.fqdn}"
+    LOG_GROUP            = "${aws_cloudwatch_log_group.publisher.name}"
+    CONTAINER_REGISTRY   = "${var.docker_registry}"
+    CONTAINER_TAG        = "${var.publisher_tag}"
+    AUTHOR_API           = "https://${aws_route53_record.author-api.fqdn}"
+    SCHEMA_VALIDATOR_URL = "${var.schema_validator_url}"
   }
 }
 

--- a/task-definitions/publisher.json
+++ b/task-definitions/publisher.json
@@ -17,7 +17,7 @@
       },
       {
         "name": "EQ_SCHEMA_VALIDATOR_URL",
-        "value": "${SCHEMA_VALIDATOR_API}/validate"
+        "value": "${SCHEMA_VALIDATOR_URL}/validate"
       }
     ],
     "logConfiguration": {

--- a/task-definitions/publisher.json
+++ b/task-definitions/publisher.json
@@ -12,8 +12,12 @@
     ],
     "environment": [
       {
-        "name": "GRAPHQL_API_URL",
+        "name": "EQ_AUTHOR_API_URL",
         "value": "${AUTHOR_API}/graphql"
+      },
+      {
+        "name": "EQ_SCHEMA_VALIDATOR_URL",
+        "value": "${SCHEMA_VALIDATOR_API}/validate"
       }
     ],
     "logConfiguration": {


### PR DESCRIPTION
### Description
 - Renames the environment variable used by Publisher to access the Author API from `GRAPHQL_API_URL` to `EQ_AUTHOR_API_URL`.
 - Adds an additional variable, `schema_validator_url` which provides the FQDN of the Schema Validator service for use by Publisher. The value is exposed to Publisher through its `EQ_SCHEMA_VALIDATOR_URL` environment variable.

### How to review
Review terraform configuration to ensure it is correct.

### Dependencies
There is a dependency on https://github.com/ONSdigital/eq-publisher/pull/45
