### PR TITLE
Change Route53 Record to Alias instead of CNAME

### DIFF
--- a/author-api.tf
+++ b/author-api.tf
@@ -35,9 +35,13 @@ resource "aws_alb_listener_rule" "author-api" {
 resource "aws_route53_record" "author-api" {
   zone_id = "${data.aws_route53_zone.dns_zone.id}"
   name    = "${var.env}-author-api.${var.dns_zone_name}"
-  type    = "CNAME"
-  ttl     = "60"
-  records = ["${data.aws_alb.eq.dns_name}"]
+  type    = "A"
+
+  alias {
+    name                   = "${data.aws_alb.eq.dns_name}"
+    zone_id                = "${data.aws_alb.eq.zone_id}"
+    evaluate_target_health = false
+  }
 }
 
 data "template_file" "author-api" {

--- a/author.tf
+++ b/author.tf
@@ -35,9 +35,13 @@ resource "aws_alb_listener_rule" "author" {
 resource "aws_route53_record" "author" {
   zone_id = "${data.aws_route53_zone.dns_zone.id}"
   name    = "${var.env}-author.${var.dns_zone_name}"
-  type    = "CNAME"
-  ttl     = "60"
-  records = ["${data.aws_alb.eq.dns_name}"]
+  type    = "A"
+
+  alias {
+    name                   = "${data.aws_alb.eq.dns_name}"
+    zone_id                = "${data.aws_alb.eq.zone_id}"
+    evaluate_target_health = false
+  }
 }
 
 data "template_file" "author" {

--- a/global_vars.tf
+++ b/global_vars.tf
@@ -82,4 +82,3 @@ variable "firebase_messaging_sender_id" {
 variable "schema_validator_url" {
   description = "The URL for the schema validator service"
 }
-

--- a/publisher.tf
+++ b/publisher.tf
@@ -35,9 +35,13 @@ resource "aws_alb_listener_rule" "publisher" {
 resource "aws_route53_record" "publisher" {
   zone_id = "${data.aws_route53_zone.dns_zone.id}"
   name    = "${var.env}-publisher.${var.dns_zone_name}"
-  type    = "CNAME"
-  ttl     = "60"
-  records = ["${data.aws_alb.eq.dns_name}"]
+  type    = "A"
+
+  alias {
+    name                   = "${data.aws_alb.eq.dns_name}"
+    zone_id                = "${data.aws_alb.eq.zone_id}"
+    evaluate_target_health = false
+  }
 }
 
 data "template_file" "publisher" {


### PR DESCRIPTION
Checks for resource record sets that can be changed to alias resource record sets to improve performance and save money. An alias resource record set routes DNS queries to an AWS resource (for example, an Elastic Load Balancing load balancer or an Amazon S3 bucket) or to another Route 53 resource record set. When you use alias resource record sets, Route 53 routes your DNS queries to AWS resources free of charge.

### How To Review
After deploying this branch with terraform
Author / Author API / Publisher should still be accessible via the url