### PR TITLE
Increase minimum number of ECS service containers

### DIFF
--- a/author-api.tf
+++ b/author-api.tf
@@ -69,7 +69,7 @@ resource "aws_ecs_service" "author-api" {
   name            = "${var.env}-author-api"
   cluster         = "${data.aws_ecs_cluster.ecs-cluster.id}"
   task_definition = "${aws_ecs_task_definition.author-api.family}"
-  desired_count   = "1"
+  desired_count   = "${var.author_api_min_tasks}"
   iam_role        = "${aws_iam_role.author-api.arn}"
 
   placement_strategy {
@@ -84,7 +84,7 @@ resource "aws_ecs_service" "author-api" {
   }
 
   lifecycle {
-    ignore_changes = ["placement_strategy"]
+    ignore_changes = ["placement_strategy", "desired_count"]
   }
 }
 

--- a/author.tf
+++ b/author.tf
@@ -75,7 +75,7 @@ resource "aws_ecs_service" "author" {
   name            = "${var.env}-author"
   cluster         = "${data.aws_ecs_cluster.ecs-cluster.id}"
   task_definition = "${aws_ecs_task_definition.author.family}"
-  desired_count   = "1"
+  desired_count   = "${var.author_min_tasks}"
   iam_role        = "${aws_iam_role.author.arn}"
 
   placement_strategy {
@@ -90,7 +90,7 @@ resource "aws_ecs_service" "author" {
   }
 
   lifecycle {
-    ignore_changes = ["placement_strategy"]
+    ignore_changes = ["placement_strategy", "desired_count"]
   }
 }
 

--- a/global_vars.tf
+++ b/global_vars.tf
@@ -82,3 +82,18 @@ variable "firebase_messaging_sender_id" {
 variable "schema_validator_url" {
   description = "The URL for the schema validator service"
 }
+
+variable "author_min_tasks" {
+  description = "The minimum number of Author tasks to run"
+  default     = "2"
+}
+
+variable "author_api_min_tasks" {
+  description = "The minimum number of Author API tasks to run"
+  default     = "2"
+}
+
+variable "publisher_min_tasks" {
+  description = "The minimum number of Publisher tasks to run"
+  default     = "2"
+}

--- a/publisher.tf
+++ b/publisher.tf
@@ -70,7 +70,7 @@ resource "aws_ecs_service" "publisher" {
   name            = "${var.env}-publisher"
   cluster         = "${data.aws_ecs_cluster.ecs-cluster.id}"
   task_definition = "${aws_ecs_task_definition.publisher.family}"
-  desired_count   = "1"
+  desired_count   = "${var.publisher_min_tasks}"
   iam_role        = "${aws_iam_role.publisher.arn}"
 
   placement_strategy {
@@ -85,7 +85,7 @@ resource "aws_ecs_service" "publisher" {
   }
 
   lifecycle {
-    ignore_changes = ["placement_strategy"]
+    ignore_changes = ["placement_strategy", "desired_count"]
   }
 }
 


### PR DESCRIPTION
Services with a single container running may experience downtime on a ECS cluster scale down.
By increasing the number to higher than 1 for PreProd and Prod then the service will not experience outage when the cluster scales back

We should also ignore changes for the desired_count. This means that if terraform is run when the environment has scaled then it wont be scaled back down by terraform
lifecycle { ignore_changes = ["desired_count"] }
hashicorp/terraform#4950