### PR TITLE
Specify Terraform AWS Provider version range >= 1.9.0

### DIFF
--- a/author-api.tf
+++ b/author-api.tf
@@ -2,7 +2,7 @@ resource "aws_alb_target_group" "author-api" {
   name     = "${var.env}-author-api"
   port     = 80
   protocol = "HTTP"
-  vpc_id   = "${data.aws_alb.eq.vpc_id}"
+  vpc_id   = "${var.vpc_id}"
 
   health_check = {
     healthy_threshold   = 2
@@ -18,7 +18,7 @@ resource "aws_alb_target_group" "author-api" {
 }
 
 resource "aws_alb_listener_rule" "author-api" {
-  listener_arn = "${var.aws_alb_listener_arn}"
+  listener_arn = "${data.aws_lb_listener.eq.id}"
   priority     = 202
 
   action {
@@ -38,8 +38,8 @@ resource "aws_route53_record" "author-api" {
   type    = "A"
 
   alias {
-    name                   = "${data.aws_alb.eq.dns_name}"
-    zone_id                = "${data.aws_alb.eq.zone_id}"
+    name                   = "${data.aws_lb.eq.dns_name}"
+    zone_id                = "${data.aws_lb.eq.zone_id}"
     evaluate_target_health = false
   }
 }

--- a/author.tf
+++ b/author.tf
@@ -2,7 +2,7 @@ resource "aws_alb_target_group" "author" {
   name     = "${var.env}-author"
   port     = 80
   protocol = "HTTP"
-  vpc_id   = "${data.aws_alb.eq.vpc_id}"
+  vpc_id   = "${var.vpc_id}"
 
   health_check = {
     healthy_threshold   = 2
@@ -18,7 +18,7 @@ resource "aws_alb_target_group" "author" {
 }
 
 resource "aws_alb_listener_rule" "author" {
-  listener_arn = "${var.aws_alb_listener_arn}"
+  listener_arn = "${data.aws_lb_listener.eq.id}"
   priority     = 201
 
   action {
@@ -38,8 +38,8 @@ resource "aws_route53_record" "author" {
   type    = "A"
 
   alias {
-    name                   = "${data.aws_alb.eq.dns_name}"
-    zone_id                = "${data.aws_alb.eq.zone_id}"
+    name                   = "${data.aws_lb.eq.dns_name}"
+    zone_id                = "${data.aws_lb.eq.zone_id}"
     evaluate_target_health = false
   }
 }

--- a/aws.tf
+++ b/aws.tf
@@ -1,4 +1,6 @@
 provider "aws" {
+  version = ">= 1.9.0"
+
   access_key = "${var.aws_access_key}"
   secret_key = "${var.aws_secret_key}"
   region     = "eu-west-1"
@@ -10,12 +12,13 @@ data "aws_ecs_cluster" "ecs-cluster" {
   cluster_name = "${var.ecs_cluster_name}"
 }
 
-data "aws_alb_listener" "eq" {
-  arn = "${var.aws_alb_listener_arn}"
+data "aws_lb_listener" "eq" {
+  load_balancer_arn = "${data.aws_lb.eq.arn}"
+  port              = "443"
 }
 
-data "aws_alb" "eq" {
-  arn = "${data.aws_alb_listener.eq.load_balancer_arn}"
+data "aws_lb" "eq" {
+  arn = "${var.aws_alb_arn}"
 }
 
 data "aws_route53_zone" "dns_zone" {

--- a/global_vars.tf
+++ b/global_vars.tf
@@ -10,12 +10,16 @@ variable "aws_access_key" {
   description = "Amazon Web Service Access Key"
 }
 
+variable "vpc_id" {
+  description = "The EQ VPC ID"
+}
+
 variable "ecs_cluster_name" {
   description = "The name of the survey runner ECS cluster"
 }
 
-variable "aws_alb_listener_arn" {
-  description = "The ARN of the survey runner ALB"
+variable "aws_alb_arn" {
+  description = "The ARN of the ALB"
 }
 
 # DNS

--- a/publisher.tf
+++ b/publisher.tf
@@ -2,7 +2,7 @@ resource "aws_alb_target_group" "publisher" {
   name     = "${var.env}-publisher"
   port     = 80
   protocol = "HTTP"
-  vpc_id   = "${data.aws_alb.eq.vpc_id}"
+  vpc_id   = "${var.vpc_id}"
 
   health_check = {
     healthy_threshold   = 2
@@ -18,7 +18,7 @@ resource "aws_alb_target_group" "publisher" {
 }
 
 resource "aws_alb_listener_rule" "publisher" {
-  listener_arn = "${var.aws_alb_listener_arn}"
+  listener_arn = "${data.aws_lb_listener.eq.id}"
   priority     = 203
 
   action {
@@ -38,8 +38,8 @@ resource "aws_route53_record" "publisher" {
   type    = "A"
 
   alias {
-    name                   = "${data.aws_alb.eq.dns_name}"
-    zone_id                = "${data.aws_alb.eq.zone_id}"
+    name                   = "${data.aws_lb.eq.dns_name}"
+    zone_id                = "${data.aws_lb.eq.zone_id}"
     evaluate_target_health = false
   }
 }

--- a/rds.tf
+++ b/rds.tf
@@ -1,7 +1,7 @@
 resource "aws_security_group" "rds_access" {
   name        = "${var.env}-rds-access-from-author"
   description = "Database access from the application subnet"
-  vpc_id      = "${data.aws_alb.eq.vpc_id}"
+  vpc_id      = "${var.vpc_id}"
 
   ingress {
     from_port   = 5432


### PR DESCRIPTION
Fixed deprecations involved with making this module compatible with terraform aws provider version 1.9.0